### PR TITLE
fix: Simplify hostname change script by removing error checks

### DIFF
--- a/exit-node-setup.sh
+++ b/exit-node-setup.sh
@@ -43,20 +43,12 @@ echo "Changing hostname from '$OLD_HOSTNAME' to '$NEW_HOSTNAME'..."
 # This updates /etc/hostname and tells the kernel the new name.
 hostnamectl set-hostname "$NEW_HOSTNAME"
 
-if [ $? -ne 0 ]; then
-  echo "Error: 'hostnamectl' command failed."
-  exit 1
-fi
 
 # 4. Update the /etc/hosts file to replace the old name
 # This finds all exact matches of the old hostname and replaces them.
 echo "Updating $HOSTS_FILE..."
 sed -i "s/\b$OLD_HOSTNAME\b/$NEW_HOSTNAME/g" "$HOSTS_FILE"
 
-if [ $? -ne 0 ]; then
-  echo "Error: Failed to update $HOSTS_FILE."
-  exit 1
-fi
 
 echo ""
 echo "Hostname change complete! 🚀"


### PR DESCRIPTION
### **User description**
Removed error handling for hostname change commands.


___

### **PR Type**
Bug fix


___

### **Description**
- Removed error handling checks after hostname change commands

- Eliminates exit conditions for `hostnamectl` and `sed` failures

- Simplifies script by removing 8 lines of error validation logic


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Hostname Change Script"] -->|Before| B["Error checks after hostnamectl"]
  B --> C["Error checks after sed"]
  A -->|After| D["Direct command execution"]
  D --> E["No error validation"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>exit-node-setup.sh</strong><dd><code>Remove error handling from hostname operations</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

exit-node-setup.sh

<ul><li>Removed error check after <code>hostnamectl set-hostname</code> command (4 lines <br>deleted)<br> <li> Removed error check after <code>sed</code> command for updating <code>/etc/hosts</code> (4 lines <br>deleted)<br> <li> Script now executes hostname change commands without validating <br>success or failure</ul>


</details>


  </td>
  <td><a href="https://github.com/GlueOps/terraform-module-tailscale/pull/15/files#diff-90d1717c2a1c251971fd99fd3fa95c3b4066f8f57a7a19e9ab0787ab64a35462">+0/-8</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

