### PR TITLE
fix: Modify hostname check to avoid unnecessary exit

### DIFF
--- a/exit-node-setup.sh
+++ b/exit-node-setup.sh
@@ -34,7 +34,6 @@ echo "Current hostname is '$OLD_HOSTNAME'."
 # 2. Check if a change is even needed
 if [ "$OLD_HOSTNAME" == "$NEW_HOSTNAME" ]; then
   echo "Hostname is already set to '$NEW_HOSTNAME'. No changes made."
-  exit 0
 fi
 
 echo "Changing hostname from '$OLD_HOSTNAME' to '$NEW_HOSTNAME'..."


### PR DESCRIPTION
### **User description**
Prevent exit when hostname is unchanged.


___

### **PR Type**
Bug fix


___

### **Description**
- Remove unnecessary exit when hostname is already set

- Allow script to continue execution after hostname check

- Prevent premature script termination on unchanged hostname


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Hostname check"] --> B{"Hostname unchanged?"}
  B -->|Before| C["exit 0"]
  B -->|After| D["Continue script"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>exit-node-setup.sh</strong><dd><code>Remove exit call from unchanged hostname condition</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

exit-node-setup.sh

<ul><li>Removed <code>exit 0</code> statement from hostname equality check<br> <li> Script now continues execution when hostname is already set<br> <li> Allows subsequent operations to proceed regardless of hostname state</ul>


</details>


  </td>
  <td><a href="https://github.com/GlueOps/terraform-module-tailscale/pull/17/files#diff-90d1717c2a1c251971fd99fd3fa95c3b4066f8f57a7a19e9ab0787ab64a35462">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

